### PR TITLE
Add cspell and lint pre-commit hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.2",
+  "language": "en",
+  "words": [
+    "Worktree",
+    "Geist"
+  ],
+  "ignorePaths": [
+    "node_modules",
+    ".next",
+    "out",
+    "package-lock.json",
+    ".centy/.centy-manifest.json"
+  ],
+  "import": [".centy/cspell.json"]
+}

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
-    "export": "next build"
+    "lint": "eslint src",
+    "export": "next build",
+    "prepare": "husky"
   },
   "dependencies": {
     "next": "^16.1.6",
@@ -20,9 +21,16 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "cspell": "^9.6.4",
     "eslint": "^9",
     "eslint-config-next": "15.1.7",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.2.7",
     "tailwindcss": "^4",
     "typescript": "^5"
+  },
+  "lint-staged": {
+    "**/*.{ts,tsx,js,jsx,mjs,cjs}": "eslint --no-warn-ignored",
+    "**/*": "cspell --no-must-find-files"
   }
 }


### PR DESCRIPTION
## Summary

- Install husky, lint-staged, and cspell as devDependencies
- Add `.husky/pre-commit` hook that runs `lint-staged` before each commit
- Add `cspell.json` config that extends `.centy/cspell.json` with project-specific words (Worktree, Geist)
- Configure `lint-staged` to run ESLint on JS/TS files and cspell on all staged files
- Update `lint` script to use `eslint src` (Next.js 16 removed `next lint`)
- Add `prepare` script to auto-install husky on `npm install`

## Test plan

- [ ] Run `npm install` and verify husky installs (prepare script runs)
- [ ] Make a commit with a spelling error and verify cspell blocks it
- [ ] Make a commit with an ESLint error and verify it is blocked
- [ ] Make a clean commit and verify it succeeds

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)