### PR TITLE
Update download buttons to link to GitHub releases

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -736,7 +736,9 @@ function InstallSection() {
                 <span className="prompt">$ </span>cargo install worktree
               </div>
               <a
-                href="#"
+                href="https://github.com/worktree-io/runner/releases"
+                target="_blank"
+                rel="noopener noreferrer"
                 className="btn-accent"
                 style={{ width: "100%", justifyContent: "center" }}
               >
@@ -781,7 +783,9 @@ function InstallSection() {
                 <span className="prompt">$ </span>cargo install worktree
               </div>
               <a
-                href="#"
+                href="https://github.com/worktree-io/runner/releases"
+                target="_blank"
+                rel="noopener noreferrer"
                 className="btn-ghost"
                 style={{ width: "100%", justifyContent: "center" }}
               >
@@ -826,7 +830,9 @@ function InstallSection() {
                 <span className="prompt">$ </span>cargo install worktree
               </div>
               <a
-                href="#"
+                href="https://github.com/worktree-io/runner/releases"
+                target="_blank"
+                rel="noopener noreferrer"
                 className="btn-ghost"
                 style={{ width: "100%", justifyContent: "center" }}
               >


### PR DESCRIPTION
## Summary
- Updated macOS, Linux, and Windows download buttons in the install section to link to `https://github.com/worktree-io/runner/releases`
- Added `target="_blank"` and `rel="noopener noreferrer"` to the external links

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)