### PR TITLE
Close centy issue #1: Add cspell and lint pre-commit hooks

### DIFF
--- a/.centy/.centy-manifest.json
+++ b/.centy/.centy-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "centyVersion": "0.7.0",
+  "centyVersion": "0.8.0",
   "createdAt": "2026-02-19T02:47:32.838665+00:00",
-  "updatedAt": "2026-02-22T18:11:17.568791+00:00"
+  "updatedAt": "2026-02-24T00:41:33.778669+00:00"
 }

--- a/.centy/issues/bdee9010-26b1-4f24-bfbe-9d2c386c2fb3.md
+++ b/.centy/issues/bdee9010-26b1-4f24-bfbe-9d2c386c2fb3.md
@@ -1,9 +1,9 @@
 ---
 displayNumber: 1
-status: in-progress
+status: closed
 priority: 2
 createdAt: 2026-02-19T02:49:22.271227+00:00
-updatedAt: 2026-02-19T02:50:08.549810+00:00
+updatedAt: 2026-02-24T00:41:33.778153+00:00
 ---
 
 # Add cspell and lint checks as pre-commit hooks


### PR DESCRIPTION
## Summary

- Closes centy issue #1 by marking it as closed in the `.centy` tracking system
- Issue #1 was already implemented and merged via GitHub PR #1

## Changes

- Updated `.centy/.centy-manifest.json` to reflect closed status
- Updated `.centy/issues/bdee9010-26b1-4f24-bfbe-9d2c386c2fb3.md` status to closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)