### PR TITLE
Stop overriding no-restricted-syntax ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,16 +1,5 @@
 import config from "eslint-config-agent";
 
-// The eslint-config-agent rules are designed for agent-generated utility/logic code.
-// src/app/ contains UI/design components that have different structural constraints
-// (long styled components, inline styles, external links in JSX, etc.).
-const uiOverrides = {
-  files: ["src/**/*.{ts,tsx}"],
-  rules: {
-    // Nullish coalescing is idiomatic in React/TS UI code
-    "no-restricted-syntax": "off",
-  },
-};
-
 // URL strings are centralized in these files; all other src files must reference these constants.
 const urlConstantsOverride = {
   files: ["src/lib/github-url.ts", "src/lib/runner-url.ts"],
@@ -19,4 +8,4 @@ const urlConstantsOverride = {
   },
 };
 
-export default [...config, uiOverrides, urlConstantsOverride];
+export default [...config, urlConstantsOverride];

--- a/src/app/open/page.tsx
+++ b/src/app/open/page.tsx
@@ -45,9 +45,12 @@ export default function OpenPage() {
 
   useEffect(() => {
     const sp = new URLSearchParams(window.location.search);
-    const owner = (sp.get("owner") ?? "").trim();
-    const repo = (sp.get("repo") ?? "").trim();
-    const issue = (sp.get("issue") ?? "").trim();
+    const ownerVal = sp.get("owner");
+    const repoVal = sp.get("repo");
+    const issueVal = sp.get("issue");
+    const owner = (ownerVal !== null ? ownerVal : "").trim();
+    const repo = (repoVal !== null ? repoVal : "").trim();
+    const issue = (issueVal !== null ? issueVal : "").trim();
 
     if (!owner || !repo || !issue) {
       setPhase("no-params");

--- a/src/app/spawn-icon.tsx
+++ b/src/app/spawn-icon.tsx
@@ -7,7 +7,7 @@ interface SpawnIconProps {
 }
 
 export function SpawnIcon({ size, className, style }: SpawnIconProps) {
-  const s = size ?? 16;
+  const s = size !== undefined ? size : 16;
   return (
     <svg
       width={s}


### PR DESCRIPTION
## Summary

- Audited all `src/` files for nullish coalescing operator (`??`) usages
- Replaced 4 occurrences with explicit null/undefined checks
  - `src/app/spawn-icon.tsx`: `size ?? 16` → `size !== undefined ? size : 16`
  - `src/app/open/page.tsx`: three `sp.get(...) ?? ""` → explicit `!== null` ternaries
- Removed the `"no-restricted-syntax": "off"` override from `eslint.config.mjs`

## Test plan

- [x] `pnpm lint` passes with zero violations
- [x] `pnpm test:visual` passes on all 27 tests (3 devices × 9 specs)
- [x] No `??` operators remain in any `src/**/*.{ts,tsx}` file

Closes ece090e7-03ad-4da5-baf0-6088f139dbfd

🤖 Generated with [Claude Code](https://claude.com/claude-code)