### PR TITLE
chore(lint): enable @typescript-eslint/consistent-type-imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,4 +8,15 @@ const urlConstantsOverride = {
   },
 };
 
-export default [...config, urlConstantsOverride];
+// Enforce `import type` for type-only imports so the TypeScript compiler can
+// fully elide them from the emitted JavaScript. Keeps type and value imports
+// distinct, avoids accidental runtime imports / side effects, and plays well
+// with bundlers and `isolatedModules`.
+const typeImportsOverride = {
+  files: ["src/**/*.{ts,tsx}"],
+  rules: {
+    "@typescript-eslint/consistent-type-imports": "error",
+  },
+};
+
+export default [...config, urlConstantsOverride, typeImportsOverride];


### PR DESCRIPTION
Closes #29

## Summary

Enables the `@typescript-eslint/consistent-type-imports` ESLint rule (`error`) for `src/**/*.{ts,tsx}` via a focused override in `eslint.config.mjs`.

The rule requires type-only imports to use the `import type { ... }` form, which lets the TypeScript compiler fully elide them from emitted JS — avoiding accidental runtime imports/side effects and improving `isolatedModules`/bundler behavior.

## Changes

- `eslint.config.mjs`: add `typeImportsOverride` enabling the single rule.

## Verification

- The codebase already follows this convention → **0 new violations**.
- `pnpm run lint` — passes.
- `pnpm run build` — passes.

No other rules touched. No production code changes.

---
_This pull request was opened by the "Add lint rule → issue + PR (owned repos + my orgs) → Slack" routine of moadim._