### PR TITLE
chore(lint): enable @typescript-eslint/no-non-null-assertion

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,4 +8,15 @@ const urlConstantsOverride = {
   },
 };
 
-export default [...config, urlConstantsOverride];
+// Forbid non-null assertions (`value!`). The `!` operator silently tells the
+// type checker a value can't be null/undefined without any runtime guarantee,
+// so a wrong assumption surfaces as a runtime crash instead of a compile error.
+// `eslint-config-agent` does not ship this rule. Prefer an explicit guard,
+// optional chaining, or narrowing instead.
+const noNonNullAssertion = {
+  rules: {
+    "@typescript-eslint/no-non-null-assertion": "error",
+  },
+};
+
+export default [...config, urlConstantsOverride, noNonNullAssertion];

--- a/src/app/open/use-auto-close.ts
+++ b/src/app/open/use-auto-close.ts
@@ -22,8 +22,7 @@ export function useAutoClose(active: boolean) {
     intervalRef.current = setInterval(() => {
       setCountdown((prev) => {
         if (prev <= 1) {
-          clearInterval(intervalRef.current!);
-          intervalRef.current = null;
+          clearTimer();
           window.close();
           return 0;
         }


### PR DESCRIPTION
## Enable the `@typescript-eslint/no-non-null-assertion` ESLint rule

Closes #35

### What
Enables `@typescript-eslint/no-non-null-assertion: "error"` in `eslint.config.mjs`, forbidding the non-null assertion operator (`value!`).

### Why
`!` tells the type checker a value is not `null`/`undefined` with **no runtime guarantee**. A wrong assumption compiles clean and crashes at runtime — the exact bug class the type system exists to catch. The rule forces an explicit guard, optional chaining, or narrowing instead. `eslint-config-agent` does not ship this rule, so `!` was previously unchecked. Set at `error` so regressions fail lint.

### Change
- `eslint.config.mjs`: add the rule (with an explanatory comment).
- `src/app/open/use-auto-close.ts`: the one violation was `clearInterval(intervalRef.current!)`. Replaced with the file's existing null-checked `clearTimer()` helper, which clears the interval and resets the ref — behavior-preserving and assertion-free.

### Verification
- `pnpm lint` → clean (0 errors).
- `tsc --noEmit` → clean.
- `next build` → succeeds (all routes prerendered).

No other rules changed.

---
This pull request was opened by the *Add lint rule → issue + PR (owned repos + my orgs) → Slack* routine of moadim. cc @tupe12334