### PR TITLE
chore: add missing changesets

### DIFF
--- a/.changeset/add-logo-favicon.md
+++ b/.changeset/add-logo-favicon.md
@@ -1,0 +1,5 @@
+---
+"landing": patch
+---
+
+Add logo and favicon (#18).

--- a/.changeset/add-open-api-versioning.md
+++ b/.changeset/add-open-api-versioning.md
@@ -1,0 +1,5 @@
+---
+"landing": minor
+---
+
+Add API versioning for the `/open` URL scheme (#27).

--- a/.changeset/download-buttons-github-releases.md
+++ b/.changeset/download-buttons-github-releases.md
@@ -1,0 +1,5 @@
+---
+"landing": patch
+---
+
+Update download buttons to link to GitHub releases (#5).

--- a/.changeset/gitlab-issue-url-support.md
+++ b/.changeset/gitlab-issue-url-support.md
@@ -1,0 +1,5 @@
+---
+"landing": minor
+---
+
+Add support for GitLab issue URLs (#24).

--- a/.changeset/mobile-responsive-layout.md
+++ b/.changeset/mobile-responsive-layout.md
@@ -1,0 +1,5 @@
+---
+"landing": minor
+---
+
+Add mobile-responsive layout and mobile e2e tests (#8).

--- a/.changeset/open-page-auto-close.md
+++ b/.changeset/open-page-auto-close.md
@@ -1,0 +1,5 @@
+---
+"landing": minor
+---
+
+Auto-close the `/open` page after 10s, with a persistent toggle to disable it (#26).

--- a/.changeset/path-based-open-versioning.md
+++ b/.changeset/path-based-open-versioning.md
@@ -1,0 +1,5 @@
+---
+"landing": patch
+---
+
+Use path-based versioning (`/v2/open`) instead of query param (`?v=2`) for the open URL scheme (#28).


### PR DESCRIPTION
Backfills `.changeset/*.md` files for merged PRs that predate retroactive Changesets adoption. Changesets tooling was bootstrapped in #38 but existing unreleased work was never backfilled.

## Covered
- #28 fix: use path-based versioning for `/v2/open`
- #27 feat: add API versioning for `/open` URL scheme
- #26 feat: auto-close `/open` page after 10s with persistent toggle
- #24 feat: add GitLab issue URL support
- #18 Add logo and favicon
- #8 Add mobile-responsive layout and mobile e2e tests
- #5 Update download buttons to link to GitHub releases

Lint/chore/dependabot-only PRs were excluded as not user-relevant. No CHANGELOG.md edits — that's generated by `changeset version`, a separate release step not run here.