### PR TITLE
chore: add missing changesets (round 2)

### DIFF
--- a/.changeset/cloudflare-pages-cicd.md
+++ b/.changeset/cloudflare-pages-cicd.md
@@ -1,0 +1,5 @@
+---
+"landing": patch
+---
+
+Add CI/CD pipeline to build and deploy the landing page to Cloudflare Pages, including PR preview deployments (#25).

--- a/.changeset/fix-action-name-reference.md
+++ b/.changeset/fix-action-name-reference.md
@@ -1,0 +1,5 @@
+---
+"landing": patch
+---
+
+Fix incorrect GitHub Action name in the landing page example: `worktree-io/action@v1` → `worktree-io/comment-action@v1` (#16).

--- a/.changeset/github-action-setup-section.md
+++ b/.changeset/github-action-setup-section.md
@@ -1,0 +1,5 @@
+---
+"landing": minor
+---
+
+Add a GitHub Action setup section to the landing page, showing the `worktree.yml` workflow and how the Action posts an "Open workspace" comment on new issues (#7).

--- a/.changeset/hooks-section-docs.md
+++ b/.changeset/hooks-section-docs.md
@@ -1,0 +1,5 @@
+---
+"landing": minor
+---
+
+Add a Hooks section documenting the `[hooks]` config block (`pre:open`/`post:open` execution order, Mustache variables, failure behavior) (#11).

--- a/.changeset/lucide-react-icons.md
+++ b/.changeset/lucide-react-icons.md
@@ -1,0 +1,5 @@
+---
+"landing": patch
+---
+
+Replace inline SVG icons with `lucide-react` components across the landing page (brand icons and the custom SpawnIcon are kept as-is) (#22).


### PR DESCRIPTION
Backfills 5 more `.changeset/*.md` files that PR #39 (the first backfill pass) missed.

## Covered
- #7 — Add GitHub Action setup section to landing page → minor
- #11 — Add Hooks section: document pre:open/post:open config options → minor
- #16 — Fix action name: worktree-io/action → worktree-io/comment-action → patch
- #22 — Close centy issue #20: replace inline SVG icons with lucide-react → patch
- #25 — Close centy issue #7: CI/CD pipeline deploy to Cloudflare Pages → patch

Lint/chore/dependabot-only PRs stay excluded as not user-relevant, matching the convention from #39. No CHANGELOG.md edits — that's generated by `changeset version`, a separate release step not run here.

---
Opened by the **Changesets keeper (owned repos + my orgs)** moadim routine.